### PR TITLE
affiches : mise du background en blanc

### DIFF
--- a/sources/fiche-open-science.svg
+++ b/sources/fiche-open-science.svg
@@ -14,7 +14,7 @@
    version="1.1"
    id="svg1932"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
-   sodipodi:docname="OPEN-MODELS_open-science.svg">
+   sodipodi:docname="fiche-open-science.svg">
   <defs
      id="defs1926" />
   <sodipodi:namedview
@@ -22,7 +22,7 @@
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="0.0"
+     inkscape:pageopacity="1"
      inkscape:pageshadow="2"
      inkscape:zoom="0.61580177"
      inkscape:cx="748.19613"
@@ -51,7 +51,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/sources/fiche-open-software.svg
+++ b/sources/fiche-open-software.svg
@@ -14,7 +14,7 @@
    version="1.1"
    id="svg1932"
    inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
-   sodipodi:docname="OPEN-MODELS_model-info.svg">
+   sodipodi:docname="fiche-open-software.svg">
   <defs
      id="defs1926" />
   <sodipodi:namedview
@@ -22,7 +22,7 @@
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="0.0"
+     inkscape:pageopacity="1"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
      inkscape:cx="493.28301"
@@ -51,7 +51,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>


### PR DESCRIPTION
Passage d'un background transparent à un background blanc pour faciliter la génération des images.

Évite d'avoir à manipuler ces propriétés lorsqu'il faut générer des images avec Inkscape.